### PR TITLE
Changed logging message to yield more information

### DIFF
--- a/codejail/jail_code.py
+++ b/codejail/jail_code.py
@@ -167,9 +167,6 @@ def jail_code(command, code=None, files=None, argv=None, stdin=None,
         os.mkdir(tmptmp)
         os.chmod(tmptmp, 0777)
 
-        if slug:
-            log.debug("Executing jailed code %s in %s", slug, homedir)
-
         argv = argv or []
 
         # All the supporting files are copied into our directory.
@@ -210,6 +207,9 @@ def jail_code(command, code=None, files=None, argv=None, stdin=None,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
         )
+
+        if slug:
+            log.debug("Executing jailed code %s in %s, with PID %s", slug, homedir, subproc.id)
 
         # Start the time killer thread.
         realtime = LIMITS["REALTIME"]


### PR DESCRIPTION
It would be convenient, for our purposes, to find out what jailed code, in particular, causes AppArmor complaints/violations/etc.

By moving this log message down, we can get the subprocess ID logged, which allows us to make useful Splunk queries.

@nedbat , do you know who else should review this?
