### PR TITLE
Fix for updated logging messages

### DIFF
--- a/codejail/jail_code.py
+++ b/codejail/jail_code.py
@@ -209,7 +209,7 @@ def jail_code(command, code=None, files=None, argv=None, stdin=None,
         )
 
         if slug:
-            log.debug("Executing jailed code %s in %s, with PID %s", slug, homedir, subproc.id)
+            log.debug("Executing jailed code %s in %s, with PID %s", slug, homedir, subproc.pid)
 
         # Start the time killer thread.
         realtime = LIMITS["REALTIME"]

--- a/codejail/tests/test_jail_code.py
+++ b/codejail/tests/test_jail_code.py
@@ -48,7 +48,8 @@ class TestFeatures(JailCodeHelpers, unittest.TestCase):
     def test_argv(self):
         res = jailpy(
             code="import sys; print ':'.join(sys.argv[1:])",
-            argv=["Hello", "world", "-x"]
+            argv=["Hello", "world", "-x"],
+            slug="a/useful/slug",
         )
         self.assertResultOk(res)
         self.assertEqual(res.stdout, "Hello:world:-x\n")


### PR DESCRIPTION
@nedbat : The addition of "a/useful/slug" should catch any errors relating to logging code in the future—let me know if you think I should write an explicit, specific test instead
