### PR TITLE
Fix temp file writing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Other details here that depend on your configuration:
         /the/path/to/your/sandbox-packages/** r,
 
         /tmp/codejail-*/ rix,
-        /tmp/codejail-*/** rix,
+        /tmp/codejail-*/** wrix,
     }
 
 6. Parse the profiles::

--- a/codejail/tests/test_jail_code.py
+++ b/codejail/tests/test_jail_code.py
@@ -33,6 +33,8 @@ class JailCodeHelpers(object):
 
     def assertResultOk(self, res):
         """Assert that `res` exited well (0), and had no stderr output."""
+        if res.stderr:
+            print "---- stderr:\n%s" % res.stderr
         self.assertEqual(res.stderr, "")        # pylint: disable=E1101
         self.assertEqual(res.status, 0)         # pylint: disable=E1101
 
@@ -207,13 +209,16 @@ class TestLimits(JailCodeHelpers, unittest.TestCase):
                 f, path = tempfile.mkstemp()
                 os.close(f)
                 with open(path, "w") as f1:
-                    f1.write("hello"*250)
-                with open(path) as f2:
-                    print "Got this:", f2.read()
+                    try:
+                        f1.write(".".join("%05d" % i for i in xrange(1000)))
+                    except IOError as e:
+                        print "Expected exception: %s" % e
+                    else:
+                        with open(path) as f2:
+                            print "Got this:", f2.read()
                 """)
-        self.assertNotEqual(res.status, 0)
-        self.assertEqual(res.stdout, "Trying mkstemp\n")
-        self.assertIn("IOError", res.stderr)
+        self.assertResultOk(res)
+        self.assertIn("Expected exception", res.stdout)
 
     def test_cant_write_many_small_temp_files(self):
         # We would like this to fail, but there's nothing that checks total


### PR DESCRIPTION
The README had an incorrect app armor config.  One of the negative tests
was passing because the test program failed, but failed for the wrong
reason.  It's now tightened up to check that it is failing for the right
reason.
