### PR TITLE
Feanil/full temp path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,7 @@ Other details here that depend on your configuration:
     $ sudo visudo -f /etc/sudoers.d/01-sandbox
 
     <SANDBOX_CALLER> ALL=(sandbox) SETENV:NOPASSWD:<SANDENV>/bin/python
+    <SANDBOX_CALLER> ALL=(sandbox) SETENV:NOPASSWD:/usr/bin/find
     <SANDBOX_CALLER> ALL=(ALL) NOPASSWD:/usr/bin/pkill
 
 5. Edit an AppArmor profile.  This is a text file specifying the limits on the

--- a/codejail/jail_code.py
+++ b/codejail/jail_code.py
@@ -197,17 +197,20 @@ def jail_code(command, code=None, files=None, extra_files=None, argv=None,
                 extra.write(content)
 
         cmd = []
+        rm_cmd = []
 
         # Build the command to run.
         user = COMMANDS[command]['user']
         if user:
             # Run as the specified user
             cmd.extend(['sudo', '-u', user])
+            rm_cmd.extend(['sudo', '-u', user])
 
         # Point TMPDIR at our temp directory.
         cmd.extend(['TMPDIR=tmp'])
         # Start with the command line dictated by "python" or whatever.
         cmd.extend(COMMANDS[command]['cmdline_start'])
+
         # Add the code-specific command line pieces.
         cmd.extend(argv)
 
@@ -230,6 +233,19 @@ def jail_code(command, code=None, files=None, extra_files=None, argv=None,
         result = JailResult()
         result.stdout, result.stderr = subproc.communicate(stdin)
         result.status = subproc.returncode
+
+        # Remove the tmptmp directory as the sandbox user
+        # since the sandbox user may have written files that
+        # the application user can't delete.
+        rm_cmd.extend([
+            '/usr/bin/find', tmptmp,
+            '-mindepth', '1', '-maxdepth', '1',
+            '-exec', 'rm', '-rf', '{}', ';'
+        ])
+
+        # Run the rm command subprocess.
+        subproc = subprocess.Popen(rm_cmd, cwd=homedir)
+        subproc.communicate()
 
     return result
 


### PR DESCRIPTION
@nedbat Figured out why the test wasn't working. We needed one more level of indirection.  When the jailed code creates temp directories with mkdtemp.
