### PR TITLE
refactor: Return new globals_dict instead of mutating an output parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,19 @@
+Changelog
+#########
+
+.. All enhancements and patches to will be documented in this file.  It adheres to the structure of https://keepachangelog.com/, but in reStructuredText instead of Markdown (for ease of incorporation into Sphinx documentation and the PyPI description). This project adheres to Semantic Versioning (https://semver.org/).
+
+.. There should always be an "Unreleased" section for changes pending release.
+
+[Unreleased]
+============
+
+Changed
+-------
+
+- **Breaking change**: ``safe_exec`` and ``not_safe_exec`` no longer modify the ``globals_dict`` parameter, and instead return a new dictionary containing the state of the globals at the end of the execution. If you wish to preserve the old behavior, you can change a call like ``safe_exec(code, globals_dict)`` to ``globals_dict.update(safe_exec(code, globals_dict))``.
+- Accordingly, ``globals_dict`` is now an optional (keyword) parameter, defaulting to ``{}``.
+
+[3.1.3] - 2020-11-09
+====================
+No changelog notes before this point; see notes on `GitHub releases <https://github.com/edx/codejail/releases>`_.

--- a/codejail/tests/test_json_safe.py
+++ b/codejail/tests/test_json_safe.py
@@ -57,3 +57,9 @@ class JsonSafeTest(unittest.TestCase):
             # Different json libraries treat these bad Unicode characters
             # differently. All we care about is that no error is raised from
             # json_safe.
+
+    def test_non_mutation(self):
+        orig = {'a': ["string", b'bytes']}
+        safe = json_safe(orig)
+        self.assertEqual(orig['a'][1], b'bytes')
+        self.assertEqual(safe['a'][1], "bytes")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="codejail",
-    version="3.1.3",
+    version="4.0.0",
     packages=['codejail'],
     install_requires=['six'],
     zip_safe=False,


### PR DESCRIPTION
BREAKING CHANGE: `safe_exec` and `not_safe_exec` no longer modify the `globals_dict` parameter, and instead return a new dictionary containing the state of the globals at the end of the execution.

Accordingly, the `globals_dict` is now an optional parameter, defaulting to an empty dictionary.

Both functions were already round-tripping the `globals_dict` through JSON so there should be no performance impact or change in the ability to make nonlocal mutations (which were already prevented by the JSON encoding). A caller who wishes to preserve the shallow mutations can simply do it themselves by changing a call like `safe_exec(code, globals_dict)` to `globals_dict.update(safe_exec(code, globals_dict))`.
