### PR TITLE
Shift codejail CI to docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
-name: Codejail AppArmor CI
-
+name: codejail-ci
 on:
+  push:
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.TOOLS_EDX_ECR_USER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TOOLS_EDX_ECR_USER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
       - name: Login to Amazon ECR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   codejail_ci:
-    name: AppArmor GitHub CI
+    name: tests
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,10 @@ jobs:
         run: |
           docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest tail -f /dev/null
       
-      - name: Check Python
-        run: docker exec -t codejail bash -c 'which python'
-      
       - name: Run Non Proxy Tests
         run: |
           docker exec -t codejail bash -c 'make clean && make test_no_proxy'
+          
       - name: Run Proxy Tests
         run: |
           docker exec -t codejail bash -c 'make clean && make test_proxy'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: Codejail AppArmor CI
+
+on:
+  pull_request:
+
+jobs:
+  codejail_ci:
+    name: AppArmor GitHub CI
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Parse custom apparmor profile
+        run: sudo apparmor_parser -r -W apparmor-profiles/home.sandbox.codejail_sandbox-python3.8.bin.python
+
+      - name: Run container with custom apparmor profile
+        run: |
+          docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile 838788427423.dkr.ecr.us-east-1.amazonaws.com/codejail:latest tail -f /dev/null
+      - name: Run Non Proxy Tests
+        run: |
+          docker exec -t codejail bash -c 'source /venv/bin/activate && make clean && make test_no_proxy'
+      - name: Run Proxy Tests
+        run: |
+          docker exec -t codejail bash -c 'source /venv/bin/activate && make clean && make test_proxy'
+
+      - name: Run Quality Tests
+        run: docker exec -t codejail bash -c 'source /venv/bin/activate && make quality'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
           docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest tail -f /dev/null
       - name: Run Non Proxy Tests
         run: |
-          docker exec -t codejail bash -c 'source /venv/bin/activate && make clean && make test_no_proxy'
+          docker exec -t codejail bash -c 'make clean && make test_no_proxy'
       - name: Run Proxy Tests
         run: |
-          docker exec -t codejail bash -c 'source /venv/bin/activate && make clean && make test_proxy'
+          docker exec -t codejail bash -c 'make clean && make test_proxy'
 
       - name: Run Quality Tests
-        run: docker exec -t codejail bash -c 'source /venv/bin/activate && make quality'
+        run: docker exec -t codejail bash -c 'make quality'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run container with custom apparmor profile
         run: |
-          docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile 838788427423.dkr.ecr.us-east-1.amazonaws.com/codejail:latest tail -f /dev/null
+          docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest tail -f /dev/null
       - name: Run Non Proxy Tests
         run: |
           docker exec -t codejail bash -c 'source /venv/bin/activate && make clean && make test_no_proxy'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
       - name: Run container with custom apparmor profile
         run: |
           docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest tail -f /dev/null
+      
+      - name: Check Python
+        run: docker exec -t codejail bash -c 'which python'
+      
       - name: Run Non Proxy Tests
         run: |
           docker exec -t codejail bash -c 'make clean && make test_no_proxy'

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ ENV CODEJAIL_TEST_VENV=/home/sandbox/codejail_sandbox-python3.8
 RUN virtualenv -p python3.8 --always-copy $CODEJAIL_TEST_VENV
 
 RUN virtualenv -p python3.8 venv
+ENV VIRTUAL_ENV=/venv
+
 
 # Create Sandbox user & group
 RUN addgroup $CODEJAIL_GROUP
@@ -36,7 +38,7 @@ WORKDIR /codejail
 RUN source $CODEJAIL_TEST_VENV/bin/activate && pip install -r requirements/sandbox.txt && deactivate
 
 # Install testing requirements
-RUN source /venv/bin/activate && pip install -r requirements/sandbox.txt && pip install -r requirements/testing.txt && deactivate
+RUN source $VIRTUAL_ENV/bin/activate && pip install -r requirements/sandbox.txt && pip install -r requirements/testing.txt
 
 
 # Setup sudoers file
@@ -50,3 +52,6 @@ RUN chown -R ubuntu:ubuntu ../codejail
 
 # Switch to ubuntu user
 USER ubuntu
+
+# Add venv/bin to path
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+FROM ubuntu:focal
+SHELL ["/bin/bash", "-c"]
+
+# Install Codejail Packages
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y vim python3-virtualenv python3-pip
+RUN apt-get install -y sudo
+
+# Define Environment Variables
+ENV CODEJAIL_GROUP=sandbox
+ENV CODEJAIL_SANDBOX_CALLER=ubuntu
+ENV CODEJAIL_TEST_USER=sandbox
+ENV CODEJAIL_TEST_VENV=/home/sandbox/codejail_sandbox-python3.8
+
+# Create Virtualenv for sandbox user
+RUN virtualenv -p python3.8 --always-copy $CODEJAIL_TEST_VENV
+
+RUN virtualenv -p python3.8 venv
+
+# Create Sandbox user & group
+RUN addgroup $CODEJAIL_GROUP
+RUN adduser --disabled-login --disabled-password $CODEJAIL_TEST_USER --ingroup $CODEJAIL_GROUP
+
+# Switch to non root user inside Docker container
+RUN addgroup ubuntu
+RUN adduser --disabled-login --disabled-password ubuntu --ingroup ubuntu
+
+# Give Ownership of sandbox env to sandbox group and user
+RUN chown -R $CODEJAIL_TEST_USER:$CODEJAIL_GROUP $CODEJAIL_TEST_VENV
+
+# Clone Codejail Repo
+ADD . ./codejail
+WORKDIR /codejail
+
+# Install codejail_sandbox sandbox dependencies
+RUN source $CODEJAIL_TEST_VENV/bin/activate && pip install -r requirements/sandbox.txt && deactivate
+
+# Install testing requirements
+RUN source /venv/bin/activate && pip install -r requirements/sandbox.txt && pip install -r requirements/testing.txt && deactivate
+
+
+# Setup sudoers file
+ADD sudoers-file/01-sandbox /etc/sudoers.d/01-sandbox
+
+# Change Sudoers file permissions
+RUN chmod 0440 /etc/sudoers.d/01-sandbox
+
+# Change Repo ownership
+RUN chown -R ubuntu:ubuntu ../codejail
+
+# Switch to ubuntu user
+USER ubuntu

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN virtualenv -p python3.8 --always-copy $CODEJAIL_TEST_VENV
 RUN virtualenv -p python3.8 venv
 ENV VIRTUAL_ENV=/venv
 
+# Add venv/bin to path
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Create Sandbox user & group
 RUN addgroup $CODEJAIL_GROUP
@@ -37,9 +39,8 @@ WORKDIR /codejail
 # Install codejail_sandbox sandbox dependencies
 RUN source $CODEJAIL_TEST_VENV/bin/activate && pip install -r requirements/sandbox.txt && deactivate
 
-# Install testing requirements
-RUN source $VIRTUAL_ENV/bin/activate && pip install -r requirements/sandbox.txt && pip install -r requirements/testing.txt
-
+# Install testing requirements in parent venv
+RUN pip install -r requirements/sandbox.txt && pip install -r requirements/testing.txt
 
 # Setup sudoers file
 ADD sudoers-file/01-sandbox /etc/sudoers.d/01-sandbox
@@ -52,6 +53,3 @@ RUN chown -R ubuntu:ubuntu ../codejail
 
 # Switch to ubuntu user
 USER ubuntu
-
-# Add venv/bin to path
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/apparmor-profiles/home.sandbox.codejail_sandbox-python3.8.bin.python
+++ b/apparmor-profiles/home.sandbox.codejail_sandbox-python3.8.bin.python
@@ -1,0 +1,27 @@
+#include <tunables/global>
+
+profile apparmor_profile /home/sandbox/codejail_sandbox-python3.8/bin/python {
+    #include <abstractions/base>
+    #include <abstractions/python>
+
+    /home/sandbox/codejail_sandbox-python3.8/** mr,
+    /tmp/codejail-*/ rix,
+    /tmp/codejail-*/** wrix,
+
+    # Whitelist particiclar shared objects from the system
+    # python installation
+    #
+    /usr/lib/python3.8/lib-dynload/_json.so mr,
+    /usr/lib/python3.8/lib-dynload/_ctypes.so mr,
+    /usr/lib/python3.8/lib-dynload/_heapq.so mr,
+    /usr/lib/python3.8/lib-dynload/_io.so mr,
+    /usr/lib/python3.8/lib-dynload/_csv.so mr,
+    /usr/lib/python3.8/lib-dynload/datetime.so mr,
+    /usr/lib/python3.8/lib-dynload/_elementtree.so mr,
+    /usr/lib/python3.8/lib-dynload/pyexpat.so mr,
+    /usr/lib/python3.8/lib-dynload/future_builtins.so mr,
+    #
+    # Allow access to selections from /proc
+    #
+    /proc/*/mounts r,
+}

--- a/sudoers-file/01-sandbox
+++ b/sudoers-file/01-sandbox
@@ -1,0 +1,7 @@
+ubuntu ALL=(sandbox) SETENV:NOPASSWD:/home/sandbox/codejail_sandbox-python3.8/bin/python
+ubuntu ALL=(sandbox) SETENV:NOPASSWD:/usr/bin/find
+ubuntu ALL=(ALL) NOPASSWD:/usr/bin/pkill
+
+Defaults!/home/sandbox/codejail_sandbox-python3.8/bin/python !requiretty
+Defaults!/usr/bin/find !requiretty
+Defaults!/usr/bin/pkill !requiretty


### PR DESCRIPTION
The `codejail CI` jobs are essentially the last public-facing jobs on https://build.testeng.edx.org/ , which we really want to shut down or at least bring behind the VPN. This PR moves the CI jobs from Jenkins to Github Actions utilizing Docker Image and parsing `apparmor` profile using Github VM. Jenkins checks will be removed in a subsequent PR.