### PR TITLE
Pull latest code changes in codejail CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,12 @@ jobs:
         run: docker pull 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest
 
       - name: Build latest code changes into CI image
-        run: docker build --cache-from 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail /
-              -t 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail .
+        run: docker build --cache-from 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail \
+            -t 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail .
 
       - name: Run container with custom apparmor profile and codejail CI image
-        run: docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile /
-              257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail tail -f /dev/null
+        run: docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile \
+            257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail tail -f /dev/null
 
       - name: Run Non Proxy Tests
         run: docker exec -t codejail bash -c 'make clean && make test_no_proxy'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.TOOLS_EDX_ECR_USER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Set Branch name
-        id: extract-branch-name
-        run: echo "BRANCH=${{ github.head_ref || github.ref_name }}" >> $GITHUB_OUTPUT
-
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
@@ -33,13 +29,13 @@ jobs:
       - name: Pull codejail CI image
         run: docker pull 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest
 
-      - name: Build latest changes into codejail Image
-        run: |
-          docker build --cache-from 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail -t 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail .
+      - name: Build latest code changes into CI image
+        run: docker build --cache-from 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail /
+              -t 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail .
 
-      - name: Run container with custom apparmor profile
-        run: |
-          docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail tail -f /dev/null
+      - name: Run container with custom apparmor profile and codejail CI image
+        run: docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile /
+              257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail tail -f /dev/null
 
       - name: Run Non Proxy Tests
         run: docker exec -t codejail bash -c 'make clean && make test_no_proxy'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,13 @@ jobs:
         run: docker pull 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest
 
       - name: Build latest code changes into CI image
-        run: docker build --cache-from 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail \
+        run: |
+          docker build --cache-from 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail \
             -t 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail .
 
       - name: Run container with custom apparmor profile and codejail CI image
-        run: docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile \
+        run: |
+          docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile \
             257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail tail -f /dev/null
 
       - name: Run Non Proxy Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,12 @@ jobs:
         run: docker pull 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest
 
       - name: Build latest changes into codejail Image
-        run: docker build -t 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail .
+        run: |
+          docker build --cache-from 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail -t 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail .
 
       - name: Run container with custom apparmor profile
-        run: docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile openedx-codejail:latest tail -f /dev/null
+        run: |
+          docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail tail -f /dev/null
 
       - name: Run Non Proxy Tests
         run: docker exec -t codejail bash -c 'make clean && make test_no_proxy'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.TOOLS_EDX_ECR_USER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
+      - name: Set Branch name
+        id: extract-branch-name
+        run: echo "BRANCH=${{ github.head_ref || github.ref_name }}" >> $GITHUB_OUTPUT
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
@@ -29,6 +33,19 @@ jobs:
       - name: Run container with custom apparmor profile
         run: |
           docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest tail -f /dev/null
+
+      - name: Pull and checkout latest code changes
+        run: |
+          docker exec -t codejail bash -c 'git pull'
+          docker exec -t codejail bash -c 'git checkout ${{ steps.extract-branch-name.outputs.BRANCH }}'
+
+      - name: Install latest requirements
+        run: |
+          docker exec -t codejail bash -c 'pip install -r requirements/sandbox.txt requirements/testing.txt'
+      
+      - name: Install latest Sandbox requirements
+        run: |
+          docker exec -t codejail bash -c 'source /home/sandbox/codejail_sandbox-python3.8/bin/activate && pip install -r requirements/sandbox.txt && deactivate'
       
       - name: Run Non Proxy Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,24 +31,19 @@ jobs:
         run: sudo apparmor_parser -r -W apparmor-profiles/home.sandbox.codejail_sandbox-python3.8.bin.python
         
       - name: Pull codejail CI image
-        run: |
-          docker pull 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest
-          docker image ls
+        run: docker pull 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest
 
       - name: Build latest changes into codejail Image
-        run: docker build -t openedx-codejail .
+        run: docker build -t 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail .
 
       - name: Run container with custom apparmor profile
-        run: |
-          docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile openedx-codejail:latest tail -f /dev/null
+        run: docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile openedx-codejail:latest tail -f /dev/null
 
       - name: Run Non Proxy Tests
-        run: |
-          docker exec -t codejail bash -c 'make clean && make test_no_proxy'
+        run: docker exec -t codejail bash -c 'make clean && make test_no_proxy'
           
       - name: Run Proxy Tests
-        run: |
-          docker exec -t codejail bash -c 'make clean && make test_proxy'
+        run: docker exec -t codejail bash -c 'make clean && make test_proxy'
 
       - name: Run Quality Tests
         run: docker exec -t codejail bash -c 'make quality'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,24 +29,17 @@ jobs:
 
       - name: Parse custom apparmor profile
         run: sudo apparmor_parser -r -W apparmor-profiles/home.sandbox.codejail_sandbox-python3.8.bin.python
+        
+      - name: Pull codejail CI image
+        run: docker pull 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest
+
+      - name: Build latest changes into codejail Image
+        run: docker build -t openedx-codejail .
 
       - name: Run container with custom apparmor profile
         run: |
-          docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest tail -f /dev/null
+          docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile openedx-codejail:latest tail -f /dev/null
 
-      - name: Pull and checkout latest code changes
-        run: |
-          docker exec -t codejail bash -c 'git pull'
-          docker exec -t codejail bash -c 'git checkout ${{ steps.extract-branch-name.outputs.BRANCH }}'
-
-      - name: Install latest requirements
-        run: |
-          docker exec -t codejail bash -c 'pip install -r requirements/sandbox.txt requirements/testing.txt'
-      
-      - name: Install latest Sandbox requirements
-        run: |
-          docker exec -t codejail bash -c 'source /home/sandbox/codejail_sandbox-python3.8/bin/activate && pip install -r requirements/sandbox.txt && deactivate'
-      
       - name: Run Non Proxy Tests
         run: |
           docker exec -t codejail bash -c 'make clean && make test_no_proxy'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
         run: sudo apparmor_parser -r -W apparmor-profiles/home.sandbox.codejail_sandbox-python3.8.bin.python
         
       - name: Pull codejail CI image
-        run: docker pull 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest
+        run: |
+          docker pull 257477529851.dkr.ecr.us-east-1.amazonaws.com/openedx-codejail:latest
+          docker image ls
 
       - name: Build latest changes into codejail Image
         run: docker build -t openedx-codejail .

--- a/codejail/tests/test_safe_exec.py
+++ b/codejail/tests/test_safe_exec.py
@@ -11,7 +11,6 @@ from codejail.jail_code import set_limit
 
 
 class TestJsonSafe(TestCase):
-    # pylint: disable=missing-class-docstring
     def test_decodable_dict(self):
         test_dict = {1: bytes('a', 'utf8'), 2: 'b', 3: {1: bytes('b', 'utf8'), 2: (1, bytes('a', 'utf8'))}}
         cleaned_dict = safe_exec.json_safe(test_dict)

--- a/codejail/tests/test_safe_exec.py
+++ b/codejail/tests/test_safe_exec.py
@@ -11,6 +11,7 @@ from codejail.jail_code import set_limit
 
 
 class TestJsonSafe(TestCase):
+    # pylint: disable=missing-class-docstring
     def test_decodable_dict(self):
         test_dict = {1: bytes('a', 'utf8'), 2: 'b', 3: {1: bytes('b', 'utf8'), 2: (1, bytes('a', 'utf8'))}}
         cleaned_dict = safe_exec.json_safe(test_dict)


### PR DESCRIPTION
Previously there was a bug in codejail CI where tests were being run on the code state which was pushed in the CI image when the image was built and not on the updated code content in the new PRs or on master. 
This PR fixes the bug and instead of pulling the image in the step where we run container, we now pull the image beforehand and then using that image as cache we build/update the image again effectively integrating new change into the image.