### PR TITLE
docs: Various fixes to codejail setup instructions (copies, user)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,7 +140,7 @@ commands at your Python terminal::
     import codejail.safe_exec
     jailed_globals = {}
     codejail.safe_exec.safe_exec("output=open('/etc/passwd').read()", jailed_globals)
-    jailed_globals
+    print(jailed_globals)  # should be unreachable if codejail is working properly
 
 This should fail with an exception. 
 

--- a/codejail/jail_code.py
+++ b/codejail/jail_code.py
@@ -282,6 +282,8 @@ def jail_code(command, code=None, files=None, extra_files=None, argv=None,
             rm_cmd.extend(['sudo', '-u', user])
 
         # Point TMPDIR at our temp directory.
+        # FIXME: This breaks command execution unless user param has been set.
+        #   Issue: https://github.com/openedx/codejail/issues/162
         cmd.extend(['TMPDIR=tmp'])
         # Start with the command line dictated by "python" or whatever.
         cmd.extend(COMMANDS[command]['cmdline_start'])


### PR DESCRIPTION
This still doesn't work as described, as codejail's confinement still denies it the ability to create a temp directory, but it's closer.

- Specify the use of `--copies` when setting up the sandbox virtualenv
- Include the `user` argument to work around TMPDIR bug (https://github.com/openedx/codejail/issues/162) and link to the issue from a code comment
- Use an unambiguous test for safe/usafe configuration (return the value using jailed globals, and bypass some issues with output streams)
- Ensure that reading codejail checkout is permitted by apparmor

Also:

- Use the venv module rather than the virtualenv command, for better compatibility with varying system configurations
- Don't bother activating virtualenv, just call its pip directly
- Note the ordinarily-unsafe presence of find in the sudoers example
- Use correct inline code syntax for rst