### PR TITLE
chore: add catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: codejail
+  description: A library for managing the execution of untrusted code in secure sandboxes.
+  annotations:
+    openedx.org/arch-interest-groups: moisesgsalas
+spec:
+  owner: user:moisesgsalas
+  type: library
+  lifecycle: production


### PR DESCRIPTION
**Description**:

Add the missing `catalog-info.yaml` metadata file so the repository can be indexed into the Open edX Backstage catalog.