### PR TITLE
feat: support for django 5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
       matrix:
         python_version: ['3.11']
         ubuntu_version: ['22.04', '24.04']
+        tox_env: [ "django42", "django52"]
+        include:
+          - tox_env: quality
+            ubuntu_version: '24.04'
+            python_version: '3.11'
 
     steps:
       - uses: actions/checkout@v4
@@ -33,11 +38,5 @@ jobs:
           docker run --name=codejail --privileged -d --security-opt apparmor=apparmor_profile \
             openedx-codejail tail -f /dev/null
 
-      - name: Run Non Proxy Tests
-        run: docker exec -t codejail bash -c 'make clean && make test_no_proxy'
-
-      - name: Run Proxy Tests
-        run: docker exec -t codejail bash -c 'make clean && make test_proxy'
-
-      - name: Run Quality Tests
-        run: docker exec -t codejail bash -c 'make quality'
+      - name: Run Tests
+        run: docker exec -e TOXENV=${{ matrix.tox_env }} -t codejail bash -c 'tox'

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,12 +53,13 @@ WORKDIR /codejail
 # Clone Requirement files
 COPY ./requirements/sandbox.txt /codejail/requirements/sandbox.txt
 COPY ./requirements/testing.txt /codejail/requirements/testing.txt
+COPY ./requirements/tox.txt /codejail/requirements/tox.txt
 
 # Install codejail_sandbox sandbox dependencies
 RUN source $CODEJAIL_TEST_VENV/bin/activate && pip install -r /codejail/requirements/sandbox.txt && deactivate
 
 # Install testing requirements in parent venv
-RUN pip install -r /codejail/requirements/sandbox.txt && pip install -r /codejail/requirements/testing.txt
+RUN pip install -r /codejail/requirements/sandbox.txt -r /codejail/requirements/testing.txt -r /codejail/requirements/tox.txt
 
 # Clone Codejail Repo
 COPY . /codejail

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ upgrade: $(COMMON_CONSTRAINTS_TXT)
 	pip-compile --annotation-style=line --upgrade -o requirements/testing.txt requirements/testing.in
 	pip-compile --annotation-style=line --upgrade -o requirements/sandbox.txt requirements/sandbox.in
 	pip-compile --annotation-style=line --upgrade -o requirements/development.txt requirements/development.in
+	# Handle Django via tox
+	sed -i '/^[dD]jango==/d' requirements/testing.txt
 
 quality: ## check coding style with pycodestyle and pylint
 	pycodestyle codejail *.py

--- a/codejail/tests/test_django_integration_utils.py
+++ b/codejail/tests/test_django_integration_utils.py
@@ -2,7 +2,10 @@
 
 from unittest import TestCase
 
+from django.conf import settings
+
 from .. import jail_code
+from ..django_integration import ConfigureCodeJailMiddleware, MiddlewareNotUsed
 from ..django_integration_utils import apply_django_settings
 from .util import ResetJailCodeStateMixin
 
@@ -147,3 +150,14 @@ class ApplyDjangoSettingsTest(ResetJailCodeStateMixin, TestCase):
                 'PROXY': 1,
             }
         )
+
+
+class InitConfigureCodeJailMiddlewareTest(TestCase):
+    """Test the ConfigureCodeJailMiddleware."""
+
+    def test_instantiate_middleware(self):
+        """Ensure is disabled after running the __init__ method."""
+        settings.configure()
+        settings.CODE_JAIL = {}
+        with self.assertRaises(expected_exception=MiddlewareNotUsed):
+            ConfigureCodeJailMiddleware(get_response=lambda x: None)

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,3 +1,1 @@
 -c common_constraints.txt
-# Django LTS version
-django>=3.2,<4.0

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -4,15 +4,18 @@
 #
 #    make upgrade
 #
+asgiref==3.8.1            # via -r requirements/testing.txt, django
 astroid==3.3.9            # via -r requirements/testing.txt, pylint
 dill==0.4.0               # via -r requirements/testing.txt, pylint
+django==4.2.21            # via -c requirements/common_constraints.txt, -r requirements/testing.txt
 iniconfig==2.1.0          # via -r requirements/testing.txt, pytest
 isort==6.0.1              # via -r requirements/testing.txt, pylint
 mccabe==0.7.0             # via -r requirements/testing.txt, pylint
 packaging==25.0           # via -r requirements/testing.txt, pytest
-platformdirs==4.3.7       # via -r requirements/testing.txt, pylint
+platformdirs==4.3.8       # via -r requirements/testing.txt, pylint
 pluggy==1.5.0             # via -r requirements/testing.txt, pytest
 pycodestyle==2.13.0       # via -r requirements/testing.txt
 pylint==3.3.7             # via -r requirements/testing.txt
 pytest==8.3.5             # via -r requirements/testing.txt
+sqlparse==0.5.3           # via -r requirements/testing.txt, django
 tomlkit==0.13.2           # via -r requirements/testing.txt, pylint

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -7,5 +7,5 @@
 wheel==0.45.1             # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.2                 # via -c /home/runner/work/codejail/codejail/requirements/common_constraints.txt, -r requirements/pip.in
+pip==24.2                 # via -c requirements/common_constraints.txt, -r requirements/pip.in
 setuptools==80.3.1        # via -r requirements/pip.in

--- a/requirements/sandbox.in
+++ b/requirements/sandbox.in
@@ -2,6 +2,5 @@
 # These requirements should be installed during the creation
 # of sandboxes used for testing codejail
 
-django
 numpy
 six

--- a/requirements/sandbox.txt
+++ b/requirements/sandbox.txt
@@ -4,9 +4,5 @@
 #
 #    make upgrade
 #
-asgiref==3.8.1            # via django
-django==3.2.25            # via -c requirements/common_constraints.txt, -c requirements/constraints.txt, -r requirements/sandbox.in
 numpy==2.2.5              # via -r requirements/sandbox.in
-pytz==2025.2              # via django
 six==1.17.0               # via -r requirements/sandbox.in
-sqlparse==0.5.3           # via django

--- a/requirements/testing.in
+++ b/requirements/testing.in
@@ -4,3 +4,4 @@ pylint
 pytest
 isort
 pycodestyle
+django

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -4,15 +4,17 @@
 #
 #    make upgrade
 #
+asgiref==3.8.1            # via django
 astroid==3.3.9            # via pylint
 dill==0.4.0               # via pylint
 iniconfig==2.1.0          # via pytest
 isort==6.0.1              # via -r requirements/testing.in, pylint
 mccabe==0.7.0             # via pylint
 packaging==25.0           # via pytest
-platformdirs==4.3.7       # via pylint
+platformdirs==4.3.8       # via pylint
 pluggy==1.5.0             # via pytest
 pycodestyle==2.13.0       # via -r requirements/testing.in
 pylint==3.3.7             # via -r requirements/testing.in
 pytest==8.3.5             # via -r requirements/testing.in
+sqlparse==0.5.3           # via django
 tomlkit==0.13.2           # via pylint

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -10,8 +10,8 @@ colorama==0.4.6           # via tox
 distlib==0.3.9            # via virtualenv
 filelock==3.18.0          # via tox, virtualenv
 packaging==25.0           # via pyproject-api, tox
-platformdirs==4.3.7       # via tox, virtualenv
+platformdirs==4.3.8       # via tox, virtualenv
 pluggy==1.5.0             # via tox
 pyproject-api==1.9.0      # via tox
 tox==4.25.0               # via -r requirements/tox.in
-virtualenv==20.30.0       # via tox
+virtualenv==20.31.2       # via tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38
+envlist = django{42,52}
 
 [testenv]
 passenv =
@@ -9,6 +9,8 @@ allowlist_externals =
     make
     mkdir
 deps =
+ 	django42: Django~=4.2
+ 	django52: Django~=5.2
     -rrequirements/testing.txt
     -rrequirements/sandbox.txt
 commands =
@@ -22,6 +24,7 @@ commands =
 allowlist_externals =
     make
 deps =
+	django~=5.2
     -rrequirements/testing.txt
 commands =
     make quality


### PR DESCRIPTION
The only usage of Django is in ConfigureCodeJailMiddleware. A small test
to check that the middleware can be correctly instantiated is included.