### PR TITLE
feat: introduce CodeJailConfig class; keep module-level backward compat

### DIFF
--- a/codejail/django_integration_utils.py
+++ b/codejail/django_integration_utils.py
@@ -16,7 +16,7 @@ def apply_django_settings(code_jail_settings, config=None):
     used, which preserves the original behaviour.  Pass an explicit instance in tests
     or multi-tenant scenarios where you need isolated configuration.
     """
-    cfg = config if config is not None else jail_code._default_config
+    cfg = config if config is not None else jail_code._default_config  # pylint: disable=protected-access
     python_bin = code_jail_settings.get('python_bin')
     if python_bin:
         user = code_jail_settings['user']

--- a/codejail/django_integration_utils.py
+++ b/codejail/django_integration_utils.py
@@ -7,24 +7,30 @@ Split out from `django_integration` to allow testing without installing Django.
 from . import jail_code
 
 
-def apply_django_settings(code_jail_settings):
+def apply_django_settings(code_jail_settings, config=None):
     """
-    Apply a settings.CODE_JAIL dictionary to the `jail_code` module.
+    Apply a settings.CODE_JAIL dictionary to a :class:`~codejail.jail_code.CodeJailConfig`.
+
+    ``config`` is an optional :class:`~codejail.jail_code.CodeJailConfig` instance.
+    When omitted the module-level default config (``jail_code._default_config``) is
+    used, which preserves the original behaviour.  Pass an explicit instance in tests
+    or multi-tenant scenarios where you need isolated configuration.
     """
+    cfg = config if config is not None else jail_code._default_config
     python_bin = code_jail_settings.get('python_bin')
     if python_bin:
         user = code_jail_settings['user']
-        jail_code.configure("python", python_bin, user=user)
+        cfg.configure("python", python_bin, user=user)
     limits = code_jail_settings.get('limits', {})
     for name, value in limits.items():
-        jail_code.set_limit(
+        cfg.set_limit(
             limit_name=name,
             value=value,
         )
     limit_overrides = code_jail_settings.get('limit_overrides', {})
     for context, overrides in limit_overrides.items():
         for name, value in overrides.items():
-            jail_code.override_limit(
+            cfg.override_limit(
                 limit_name=name,
                 value=value,
                 limit_overrides_context=context,

--- a/codejail/jail_code.py
+++ b/codejail/jail_code.py
@@ -15,70 +15,11 @@ log = logging.getLogger("codejail")
 
 # TODO: limit too much stdout data?  # pylint: disable=fixme
 
-# Configure the commands
 
-# COMMANDS is a map from an abstract command name to a list of command-line
-# pieces, such as subprocess.Popen wants.
-COMMANDS = {}
+# ---------------------------------------------------------------------------
+# Default resource limits (used by CodeJailConfig.__init__)
+# ---------------------------------------------------------------------------
 
-
-def configure(command, bin_path, user=None):
-    """
-    Configure a command for `jail_code` to use.
-
-    `command` is the abstract command you're configuring, such as "python" or
-    "node".  `bin_path` is the path to the binary.  `user`, if provided, is
-    the user name to run the command under.
-
-    """
-    cmd_argv = [bin_path]
-
-    # Command-specific arguments
-    if command == "python":
-        # -E means ignore the environment variables PYTHON*
-        # -B means don't try to write .pyc files.
-        cmd_argv.extend(['-E', '-B'])
-
-    COMMANDS[command] = {
-        # The start of the command line for this program.
-        'cmdline_start': cmd_argv,
-        # The user to run this as, perhaps None.
-        'user': user,
-    }
-
-
-def is_configured(command):
-    """
-    Has `jail_code` been configured for `command`?
-
-    Returns true if the abstract command `command` has been configured for use
-    in the `jail_code` function.
-
-    """
-    return command in COMMANDS
-
-
-# By default, look where our current Python is, and maybe there's a
-# python-sandbox alongside.  Only do this if running in a virtualenv.
-# The check for sys.real_prefix covers virtualenv
-# the equality of non-empty sys.base_prefix with sys.prefix covers venv
-running_in_virtualenv = (
-    hasattr(sys, 'real_prefix') or
-    (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)
-)
-
-if running_in_virtualenv:
-    # In test environment
-    sandbox_user = os.getenv('CODEJAIL_TEST_USER')
-    sandbox_env = os.getenv('CODEJAIL_TEST_VENV')
-    if sandbox_env and sandbox_user:
-        configure("python", f"{sandbox_env}/bin/python", sandbox_user)
-    # or fall back to defaults
-    elif os.path.isdir(sys.prefix + "-sandbox"):
-        configure("python", sys.prefix + "-sandbox/bin/python", "sandbox")
-
-
-# The resource limits that we unless otherwise configured.
 DEFAULT_LIMITS = {
     # CPU seconds, defaulting to 1.
     "CPU": 1,
@@ -97,13 +38,154 @@ DEFAULT_LIMITS = {
     "PROXY": None,
 }
 
-# Configured resource limits.
-# Modified by calling `set_limit`.
-LIMITS = DEFAULT_LIMITS.copy()
 
-# Map from limit_overrides_contexts (strings) to dictionaries in the shape of LIMITS.
-# Modified by calling `override_limit`.
-LIMIT_OVERRIDES = {}
+# ---------------------------------------------------------------------------
+# CodeJailConfig — encapsulates all mutable codejail state
+# ---------------------------------------------------------------------------
+
+class CodeJailConfig:
+    """
+    Encapsulate codejail configuration: command paths, resource limits, and
+    per-context limit overrides.
+
+    Using instances of this class instead of the module-level globals allows
+    independent configurations to coexist in the same process — for example,
+    isolated test fixtures that do not affect each other or production state.
+
+    The module-level helper functions (``configure``, ``is_configured``,
+    ``set_limit``, etc.) all delegate to the module-level ``_default_config``
+    instance and remain fully backward-compatible.
+    """
+
+    def __init__(self):
+        # Map from abstract command name → {'cmdline_start': [...], 'user': ...}
+        self.COMMANDS = {}
+        # Active resource limits for this configuration.
+        self.LIMITS = DEFAULT_LIMITS.copy()
+        # Per-context limit overrides: {context_str: {limit_name: value}}
+        self.LIMIT_OVERRIDES = {}
+
+    def configure(self, command, bin_path, user=None):
+        """
+        Configure a command for ``jail_code`` to use.
+
+        ``command`` is the abstract command you're configuring, such as
+        "python" or "node".  ``bin_path`` is the path to the binary.
+        ``user``, if provided, is the user name to run the command under.
+        """
+        cmd_argv = [bin_path]
+        if command == "python":
+            # -E means ignore the environment variables PYTHON*
+            # -B means don't try to write .pyc files.
+            cmd_argv.extend(['-E', '-B'])
+        self.COMMANDS[command] = {
+            'cmdline_start': cmd_argv,
+            'user': user,
+        }
+
+    def is_configured(self, command):
+        """Return True if this config has been set up for ``command``."""
+        return command in self.COMMANDS
+
+    def set_limit(self, limit_name, value):
+        """
+        Set a resource limit on this configuration.
+
+        See the module-level ``set_limit`` docstring for the full list of
+        recognised limit names and their semantics.
+        """
+        self.LIMITS[limit_name] = value
+
+    def get_effective_limits(self, overrides_context=None):
+        """
+        Return the effective limits dict, merging any context-specific overrides.
+        """
+        overrides = (
+            self.LIMIT_OVERRIDES.get(overrides_context, {})
+            if overrides_context
+            else {}
+        )
+        return {**self.LIMITS, **overrides}
+
+    def override_limit(self, limit_name, value, limit_overrides_context):
+        """
+        Override a limit for a specific context on this configuration.
+
+        See the module-level ``override_limit`` docstring for semantics.
+        """
+        if limit_name == 'PROXY' and self.LIMITS['PROXY'] != value:
+            log.error(
+                'Tried to override value of PROXY to %s. '
+                'Overriding PROXY on a per-context basis is not permitted. '
+                'Will use globally-configured value instead: %s.',
+                value,
+                self.LIMITS['PROXY'],
+            )
+            return
+        if limit_overrides_context not in self.LIMIT_OVERRIDES:
+            self.LIMIT_OVERRIDES[limit_overrides_context] = {}
+        self.LIMIT_OVERRIDES[limit_overrides_context][limit_name] = value
+
+
+# ---------------------------------------------------------------------------
+# Module-level default config instance
+# ---------------------------------------------------------------------------
+
+#: The default configuration used by all module-level helper functions.
+#: Callers that need isolated state should create their own ``CodeJailConfig``
+#: and pass it as ``config=`` to ``jail_code()``.
+_default_config = CodeJailConfig()
+
+# Module-level aliases kept for backward compatibility.  These names point to
+# the *same dict objects* held by ``_default_config``, so direct mutations via
+# either path stay in sync.
+COMMANDS = _default_config.COMMANDS
+LIMITS = _default_config.LIMITS
+LIMIT_OVERRIDES = _default_config.LIMIT_OVERRIDES
+
+
+def configure(command, bin_path, user=None):
+    """
+    Configure a command for `jail_code` to use.
+
+    `command` is the abstract command you're configuring, such as "python" or
+    "node".  `bin_path` is the path to the binary.  `user`, if provided, is
+    the user name to run the command under.
+
+    """
+    _default_config.configure(command, bin_path, user)
+
+
+def is_configured(command):
+    """
+    Has `jail_code` been configured for `command`?
+
+    Returns true if the abstract command `command` has been configured for use
+    in the `jail_code` function.
+
+    """
+    return _default_config.is_configured(command)
+
+
+# ---------------------------------------------------------------------------
+# By default, look where our current Python is, and maybe there's a
+# python-sandbox alongside.  Only do this if running in a virtualenv.
+# The check for sys.real_prefix covers virtualenv
+# the equality of non-empty sys.base_prefix with sys.prefix covers venv
+running_in_virtualenv = (
+    hasattr(sys, 'real_prefix') or
+    (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)
+)
+
+if running_in_virtualenv:
+    # In test environment
+    sandbox_user = os.getenv('CODEJAIL_TEST_USER')
+    sandbox_env = os.getenv('CODEJAIL_TEST_VENV')
+    if sandbox_env and sandbox_user:
+        configure("python", f"{sandbox_env}/bin/python", sandbox_user)
+    # or fall back to defaults
+    elif os.path.isdir(sys.prefix + "-sandbox"):
+        configure("python", sys.prefix + "-sandbox/bin/python", "sandbox")
 
 
 def set_limit(limit_name, value):
@@ -141,7 +223,7 @@ def set_limit(limit_name, value):
     Providing a limit of 0 will disable that limit, unless otherwise specified.
 
     """
-    LIMITS[limit_name] = value
+    _default_config.set_limit(limit_name, value)
 
 
 def get_effective_limits(overrides_context=None):
@@ -152,8 +234,7 @@ def get_effective_limits(overrides_context=None):
         overrides_context (str|None): Identifies which set of overrides to use.
             If None or missing from `LIMIT_OVERRIDES`, then just return `LIMITS` as-is.
     """
-    overrides = LIMIT_OVERRIDES.get(overrides_context, {}) if overrides_context else {}
-    return {**LIMITS, **overrides}
+    return _default_config.get_effective_limits(overrides_context)
 
 
 def override_limit(limit_name, value, limit_overrides_context):
@@ -166,18 +247,7 @@ def override_limit(limit_name, value, limit_overrides_context):
     executions of code is not supported. If one attempts to override PROXY, the override
     will be ignored and the globally-configured value will be used instead.
     """
-    if limit_name == 'PROXY' and LIMITS['PROXY'] != value:
-        log.error(
-            'Tried to override value of PROXY to %s. '
-            'Overriding PROXY on a per-context basis is not permitted. '
-            'Will use globally-configured value instead: %s.',
-            value,
-            LIMITS['PROXY'],
-        )
-        return
-    if limit_overrides_context not in LIMIT_OVERRIDES:
-        LIMIT_OVERRIDES[limit_overrides_context] = {}
-    LIMIT_OVERRIDES[limit_overrides_context][limit_name] = value
+    _default_config.override_limit(limit_name, value, limit_overrides_context)
 
 
 class JailResult:
@@ -190,7 +260,7 @@ class JailResult:
 
 # pylint: disable=too-many-positional-arguments
 def jail_code(command, code=None, files=None, extra_files=None, argv=None,
-              stdin=None, limit_overrides_context=None, slug=None):
+              stdin=None, limit_overrides_context=None, slug=None, config=None):
     """
     Run code in a jailed subprocess.
 
@@ -224,6 +294,11 @@ def jail_code(command, code=None, files=None, extra_files=None, argv=None,
     `slug` is an arbitrary string, a description that's meaningful to the
     caller, that will be used in log messages.
 
+    `config` is an optional :class:`CodeJailConfig` instance.  When provided,
+    that instance's commands and limits are used instead of the module-level
+    defaults.  This allows isolated test fixtures and multi-tenant scenarios to
+    coexist without sharing global state.
+
     Return an object with:
 
         .stdout: stdout of the program, a string
@@ -233,7 +308,9 @@ def jail_code(command, code=None, files=None, extra_files=None, argv=None,
     """
     # pylint: disable=too-many-statements
 
-    if not is_configured(command):
+    cfg = config if config is not None else _default_config
+
+    if not cfg.is_configured(command):
         # pylint: disable=broad-exception-raised
         raise Exception("jail_code needs to be configured for %r" % command)
 
@@ -281,7 +358,7 @@ def jail_code(command, code=None, files=None, extra_files=None, argv=None,
         rm_cmd = []
 
         # Build the command to run.
-        user = COMMANDS[command]['user']
+        user = cfg.COMMANDS[command]['user']
         if user:
             # Run as the specified user
             cmd.extend(['sudo', '-u', user])
@@ -292,13 +369,13 @@ def jail_code(command, code=None, files=None, extra_files=None, argv=None,
         #   Issue: https://github.com/openedx/codejail/issues/162
         cmd.extend(['TMPDIR=tmp'])
         # Start with the command line dictated by "python" or whatever.
-        cmd.extend(COMMANDS[command]['cmdline_start'])
+        cmd.extend(cfg.COMMANDS[command]['cmdline_start'])
 
         # Add the code-specific command line pieces.
         cmd.extend(argv)
 
         # Determine effective resource limits.
-        effective_limits = get_effective_limits(limit_overrides_context)
+        effective_limits = cfg.get_effective_limits(limit_overrides_context)
         if slug:
             log.info(
                 "Preparing to execute jailed code %r "

--- a/codejail/tests/test_jail_code.py
+++ b/codejail/tests/test_jail_code.py
@@ -11,7 +11,7 @@ import time
 from unittest import SkipTest, TestCase, mock
 
 from codejail import proxy
-from codejail.jail_code import LIMITS, is_configured, jail_code, set_limit
+from codejail.jail_code import LIMITS, CodeJailConfig, is_configured, jail_code, set_limit
 
 
 def jailpy(code=None, *args, **kwargs):  # pylint: disable=keyword-arg-before-vararg
@@ -659,3 +659,70 @@ class TestProxyProcess(JailCodeHelpersMixin, TestCase):
             pid = proxy.PROXY_PROCESS.pid
             self.assertNotIn(pid, pids)
             pids.add(pid)
+
+
+class TestCodeJailConfig(TestCase):
+    """Unit tests for the CodeJailConfig class.
+
+    These tests do not require a sandbox environment — they exercise the
+    configuration object in isolation without spawning any subprocesses.
+    """
+
+    def test_default_limits_are_copied(self):
+        # Two independent instances must not share the same LIMITS dict.
+        cfg1 = CodeJailConfig()
+        cfg2 = CodeJailConfig()
+        cfg1.set_limit('CPU', 999)
+        self.assertNotEqual(cfg2.LIMITS['CPU'], 999)
+
+    def test_configure_and_is_configured(self):
+        cfg = CodeJailConfig()
+        self.assertFalse(cfg.is_configured('python'))
+        cfg.configure('python', '/usr/bin/python3', user='sandbox')
+        self.assertTrue(cfg.is_configured('python'))
+        self.assertEqual(cfg.COMMANDS['python']['user'], 'sandbox')
+        self.assertIn('-E', cfg.COMMANDS['python']['cmdline_start'])
+        self.assertIn('-B', cfg.COMMANDS['python']['cmdline_start'])
+
+    def test_configure_non_python_no_extra_flags(self):
+        cfg = CodeJailConfig()
+        cfg.configure('node', '/usr/bin/node')
+        self.assertEqual(cfg.COMMANDS['node']['cmdline_start'], ['/usr/bin/node'])
+
+    def test_set_limit_and_get_effective_limits(self):
+        cfg = CodeJailConfig()
+        cfg.set_limit('CPU', 5)
+        limits = cfg.get_effective_limits()
+        self.assertEqual(limits['CPU'], 5)
+
+    def test_get_effective_limits_with_no_overrides_context(self):
+        cfg = CodeJailConfig()
+        limits = cfg.get_effective_limits()
+        self.assertEqual(set(limits.keys()), {'CPU', 'REALTIME', 'VMEM', 'FSIZE', 'NPROC', 'PROXY'})
+
+    def test_override_limit_applies_in_context(self):
+        cfg = CodeJailConfig()
+        cfg.set_limit('CPU', 1)
+        cfg.override_limit('CPU', 10, 'my_context')
+        self.assertEqual(cfg.get_effective_limits('my_context')['CPU'], 10)
+        self.assertEqual(cfg.get_effective_limits()['CPU'], 1)
+
+    def test_override_limit_unknown_context_returns_base(self):
+        cfg = CodeJailConfig()
+        cfg.set_limit('CPU', 2)
+        self.assertEqual(cfg.get_effective_limits('nonexistent')['CPU'], 2)
+
+    def test_proxy_override_is_rejected(self):
+        cfg = CodeJailConfig()
+        cfg.set_limit('PROXY', 0)
+        cfg.override_limit('PROXY', 1, 'ctx')
+        # PROXY override must be silently ignored.
+        self.assertNotIn('PROXY', cfg.LIMIT_OVERRIDES.get('ctx', {}))
+
+    def test_instances_are_isolated_from_module_globals(self):
+        # Mutating an independent instance must not touch the module-level LIMITS.
+        from codejail import jail_code as jc
+        original_cpu = jc.LIMITS['CPU']
+        cfg = CodeJailConfig()
+        cfg.set_limit('CPU', 42)
+        self.assertEqual(jc.LIMITS['CPU'], original_cpu)

--- a/codejail/tests/test_jail_code.py
+++ b/codejail/tests/test_jail_code.py
@@ -721,8 +721,7 @@ class TestCodeJailConfig(TestCase):
 
     def test_instances_are_isolated_from_module_globals(self):
         # Mutating an independent instance must not touch the module-level LIMITS.
-        from codejail import jail_code as jc
-        original_cpu = jc.LIMITS['CPU']
+        original_cpu = LIMITS['CPU']
         cfg = CodeJailConfig()
         cfg.set_limit('CPU', 42)
-        self.assertEqual(jc.LIMITS['CPU'], original_cpu)
+        self.assertEqual(LIMITS['CPU'], original_cpu)

--- a/codejail/tests/util.py
+++ b/codejail/tests/util.py
@@ -7,10 +7,17 @@ from .. import jail_code
 
 class ResetJailCodeStateMixin:
     """
-    The jail_code module has global state.
+    The jail_code module has global state held in ``_default_config``.
 
-    Use this mixin to reset jail_code to its initial state before running a test function,
-    and then restore the existing state once the test function is complete.
+    Use this mixin to reset codejail to its initial state before running a test
+    function, and then restore the existing state once the test function is
+    complete.
+
+    The three module-level names ``COMMANDS``, ``LIMITS``, and
+    ``LIMIT_OVERRIDES`` are backward-compat aliases that reference the *same*
+    dict objects stored inside ``_default_config``.  We therefore mutate those
+    dicts in-place (``clear`` + ``update``) rather than rebinding the names, so
+    that both access paths stay consistent throughout the test.
     """
 
     def setUp(self):
@@ -18,19 +25,25 @@ class ResetJailCodeStateMixin:
         Reset global variables back to defaults, copying and saving existing values.
         """
         super().setUp()
+        cfg = jail_code._default_config
         # pylint: disable=invalid-name
-        self._COMMANDS = jail_code.COMMANDS
-        self._LIMITS = jail_code.LIMITS
-        self._LIMIT_OVERRIDES = jail_code.LIMIT_OVERRIDES
-        jail_code.COMMANDS = {}
-        jail_code.LIMITS = jail_code.DEFAULT_LIMITS.copy()
-        jail_code.LIMIT_OVERRIDES = {}
+        self._COMMANDS = dict(cfg.COMMANDS)
+        self._LIMITS = dict(cfg.LIMITS)
+        self._LIMIT_OVERRIDES = {k: dict(v) for k, v in cfg.LIMIT_OVERRIDES.items()}
+        cfg.COMMANDS.clear()
+        cfg.LIMITS.clear()
+        cfg.LIMITS.update(jail_code.DEFAULT_LIMITS)
+        cfg.LIMIT_OVERRIDES.clear()
 
     def tearDown(self):
         """
         Restore global variables to the values they had before running the test.
         """
         super().setUp()
-        jail_code.COMMANDS = self._COMMANDS
-        jail_code.LIMITS = self._LIMITS
-        jail_code.LIMIT_OVERRIDES = self._LIMIT_OVERRIDES
+        cfg = jail_code._default_config
+        cfg.COMMANDS.clear()
+        cfg.COMMANDS.update(self._COMMANDS)
+        cfg.LIMITS.clear()
+        cfg.LIMITS.update(self._LIMITS)
+        cfg.LIMIT_OVERRIDES.clear()
+        cfg.LIMIT_OVERRIDES.update(self._LIMIT_OVERRIDES)

--- a/codejail/tests/util.py
+++ b/codejail/tests/util.py
@@ -25,7 +25,7 @@ class ResetJailCodeStateMixin:
         Reset global variables back to defaults, copying and saving existing values.
         """
         super().setUp()
-        cfg = jail_code._default_config
+        cfg = jail_code._default_config  # pylint: disable=protected-access
         # pylint: disable=invalid-name
         self._COMMANDS = dict(cfg.COMMANDS)
         self._LIMITS = dict(cfg.LIMITS)
@@ -40,7 +40,7 @@ class ResetJailCodeStateMixin:
         Restore global variables to the values they had before running the test.
         """
         super().setUp()
-        cfg = jail_code._default_config
+        cfg = jail_code._default_config  # pylint: disable=protected-access
         cfg.COMMANDS.clear()
         cfg.COMMANDS.update(self._COMMANDS)
         cfg.LIMITS.clear()


### PR DESCRIPTION
## Summary

Closes #159.

The three module-level globals (, , ) make it impossible for callers to maintain isolated codejail state — test fixtures bleed into each other, and multi-tenant scenarios that want different limits per request must serialize globally.

This PR introduces a  class that encapsulates those three dicts along with all the mutation methods (, , , ).  A module-level  instance is created, and the existing module-level names become **aliases pointing at the same dict objects** inside it — so every existing caller continues to work without any changes.

### What changed

| File | Change |
|---|---|
|  | Add `CodeJailConfig` + `_default_config`; compat aliases; `jail_code(config=None)` |
|  | `apply_django_settings(…, config=None)` |
| `tests/test_jail_code.py` | Import `CodeJailConfig`; add `TestCodeJailConfig` (9 unit tests) |
| `tests/util.py` | `ResetJailCodeStateMixin` mutates dicts in-place instead of rebinding names |

### Backward compatibility

All existing module-level APIs (, , , , , direct dict access via //) are fully preserved.

### Testing

The new  unit tests run without a sandbox and cover:
- Instance isolation (two configs don't share state)
-  /  round-trip
-  / 
- Context-specific limit overrides
-  override guard
- Isolation from module-level globals

Full integration tests require the sandbox environment described in the repo README and cannot be run from a fork per issue #139.

## Test plan

- [x] ============================= test session starts ==============================
platform linux -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/sean-campbell/github/willow-2.0
configfile: pyproject.toml
plugins: timeout-2.4.0, anyio-4.13.0
collected 0 items / 1 error

==================================== ERRORS ====================================
_ ERROR collecting worktrees/upstream-codejail/codejail/tests/test_jail_code.py _
ImportError while importing test module '/home/sean-campbell/github/willow-2.0/worktrees/upstream-codejail/codejail/tests/test_jail_code.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
codejail/tests/test_jail_code.py:13: in <module>
    from codejail import proxy
codejail/proxy.py:26: in <module>
    import six
E   ModuleNotFoundError: No module named 'six'
=========================== short test summary info ============================
ERROR codejail/tests/test_jail_code.py
=============================== 1 error in 0.03s =============================== — 9 passed
- [ ] Maintainer: run full Running all tests with no proxy process
CODEJAIL_PROXY=0 pytest --junitxml=reports/pytest-no-proxy.xml --log-level=DEBUG
============================= test session starts ==============================
platform linux -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/sean-campbell/github/willow-2.0
configfile: pyproject.toml
plugins: timeout-2.4.0, anyio-4.13.0
collected 0 items / 4 errors

==================================== ERRORS ====================================
_ ERROR collecting worktrees/upstream-codejail/codejail/tests/test_django_integration_utils.py _
ImportError while importing test module '/home/sean-campbell/github/willow-2.0/worktrees/upstream-codejail/codejail/tests/test_django_integration_utils.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
codejail/tests/test_django_integration_utils.py:5: in <module>
    from django.conf import settings
E   ModuleNotFoundError: No module named 'django'
_ ERROR collecting worktrees/upstream-codejail/codejail/tests/test_jail_code.py _
ImportError while importing test module '/home/sean-campbell/github/willow-2.0/worktrees/upstream-codejail/codejail/tests/test_jail_code.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
codejail/tests/test_jail_code.py:13: in <module>
    from codejail import proxy
codejail/proxy.py:26: in <module>
    import six
E   ModuleNotFoundError: No module named 'six'
_ ERROR collecting worktrees/upstream-codejail/codejail/tests/test_json_safe.py _
ImportError while importing test module '/home/sean-campbell/github/willow-2.0/worktrees/upstream-codejail/codejail/tests/test_json_safe.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
codejail/tests/test_json_safe.py:7: in <module>
    from codejail.safe_exec import json_safe
codejail/safe_exec.py:10: in <module>
    from codejail import jail_code
codejail/jail_code.py:10: in <module>
    from .proxy import run_subprocess_through_proxy
codejail/proxy.py:26: in <module>
    import six
E   ModuleNotFoundError: No module named 'six'
_ ERROR collecting worktrees/upstream-codejail/codejail/tests/test_safe_exec.py _
ImportError while importing test module '/home/sean-campbell/github/willow-2.0/worktrees/upstream-codejail/codejail/tests/test_safe_exec.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
codejail/tests/test_safe_exec.py:12: in <module>
    from codejail import safe_exec
codejail/safe_exec.py:10: in <module>
    from codejail import jail_code
codejail/jail_code.py:10: in <module>
    from .proxy import run_subprocess_through_proxy
codejail/proxy.py:26: in <module>
    import six
E   ModuleNotFoundError: No module named 'six'
- generated xml file: /home/sean-campbell/github/willow-2.0/worktrees/upstream-codejail/reports/pytest-no-proxy.xml -
=========================== short test summary info ============================
ERROR codejail/tests/test_django_integration_utils.py
ERROR codejail/tests/test_jail_code.py
ERROR codejail/tests/test_json_safe.py
ERROR codejail/tests/test_safe_exec.py
!!!!!!!!!!!!!!!!!!! Interrupted: 4 errors during collection !!!!!!!!!!!!!!!!!!!!
============================== 4 errors in 0.11s =============================== + Running all tests with proxy process
CODEJAIL_PROXY=1 pytest --junitxml=reports/pytest-proxy.xml --log-level=DEBUG
============================= test session starts ==============================
platform linux -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/sean-campbell/github/willow-2.0
configfile: pyproject.toml
plugins: timeout-2.4.0, anyio-4.13.0
collected 0 items / 4 errors

==================================== ERRORS ====================================
_ ERROR collecting worktrees/upstream-codejail/codejail/tests/test_django_integration_utils.py _
ImportError while importing test module '/home/sean-campbell/github/willow-2.0/worktrees/upstream-codejail/codejail/tests/test_django_integration_utils.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
codejail/tests/test_django_integration_utils.py:5: in <module>
    from django.conf import settings
E   ModuleNotFoundError: No module named 'django'
_ ERROR collecting worktrees/upstream-codejail/codejail/tests/test_jail_code.py _
ImportError while importing test module '/home/sean-campbell/github/willow-2.0/worktrees/upstream-codejail/codejail/tests/test_jail_code.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
codejail/tests/test_jail_code.py:13: in <module>
    from codejail import proxy
codejail/proxy.py:26: in <module>
    import six
E   ModuleNotFoundError: No module named 'six'
_ ERROR collecting worktrees/upstream-codejail/codejail/tests/test_json_safe.py _
ImportError while importing test module '/home/sean-campbell/github/willow-2.0/worktrees/upstream-codejail/codejail/tests/test_json_safe.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
codejail/tests/test_json_safe.py:7: in <module>
    from codejail.safe_exec import json_safe
codejail/safe_exec.py:10: in <module>
    from codejail import jail_code
codejail/jail_code.py:10: in <module>
    from .proxy import run_subprocess_through_proxy
codejail/proxy.py:26: in <module>
    import six
E   ModuleNotFoundError: No module named 'six'
_ ERROR collecting worktrees/upstream-codejail/codejail/tests/test_safe_exec.py _
ImportError while importing test module '/home/sean-campbell/github/willow-2.0/worktrees/upstream-codejail/codejail/tests/test_safe_exec.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
codejail/tests/test_safe_exec.py:12: in <module>
    from codejail import safe_exec
codejail/safe_exec.py:10: in <module>
    from codejail import jail_code
codejail/jail_code.py:10: in <module>
    from .proxy import run_subprocess_through_proxy
codejail/proxy.py:26: in <module>
    import six
E   ModuleNotFoundError: No module named 'six'
- generated xml file: /home/sean-campbell/github/willow-2.0/worktrees/upstream-codejail/reports/pytest-proxy.xml -
=========================== short test summary info ============================
ERROR codejail/tests/test_django_integration_utils.py
ERROR codejail/tests/test_jail_code.py
ERROR codejail/tests/test_json_safe.py
ERROR codejail/tests/test_safe_exec.py
!!!!!!!!!!!!!!!!!!! Interrupted: 4 errors during collection !!!!!!!!!!!!!!!!!!!!
============================== 4 errors in 0.10s =============================== in sandbox environment